### PR TITLE
DryIoc works with DryIoc.MS.DI v6-preview-02 with IServiceProviderIsService implemented

### DIFF
--- a/MinimalWeb.csproj
+++ b/MinimalWeb.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="LightInject.Microsoft.Hosting" Version="1.2.5" /> -->
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.0.0-preview-01" />
+    <PackageReference Include="LightInject.Microsoft.Hosting" Version="1.2.5" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.0.0-preview-02" />
   </ItemGroup>
 
 </Project>

--- a/MinimalWeb.csproj
+++ b/MinimalWeb.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LightInject.Microsoft.Hosting" Version="1.2.5" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.0.0-preview-02" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,18 +1,16 @@
-// using LightInject;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Uncomment this line and it will not inject Foo anymore
-// builder.Host.UseLightInject();
+var container = new Container(Rules.MicrosoftDependencyInjectionRules);
 
-// Uncomment to see both routes work:
-// var container = new Container(Rules.MicrosoftDependencyInjectionRules);
-// container.Register<Bar>();
-// builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(container));
+// register natively with DryIoc
+container.Register<Bar>();
 
+builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(container));
 
+// register via Services collection
 builder.Services.AddTransient<Foo>();
 
 var app = builder.Build();

--- a/Program.cs
+++ b/Program.cs
@@ -1,32 +1,30 @@
 // using LightInject;
+using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Uncomment this line and it will not inject Foo anymore
-//builder.Host.UseLightInject();
+// builder.Host.UseLightInject();
 
-// Uncomment and trying to open the app link will result in the error:
-// ```
-// fail: Microsoft.AspNetCore.Server.Kestrel[13]
-//       Connection id "0HMBCQ2M8Q5IF", Request id "0HMBCQ2M8Q5IF:00000001": An unhandled exception was thrown by the application.
-//       System.InvalidOperationException: Unable to read the request as JSON because the request content type '' is not a known JSON content type.
-//          at Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.ReadFromJsonAsync(HttpRequest request, Type type, JsonSerializerOptions options, CancellationToken cancellationToken) in Microsoft.AspNetCore.Http.Extensions.dll:token 0x600004b+0x1f6
-//          at Microsoft.AspNetCore.Http.RequestDelegateFactory.<>c__DisplayClass38_0.<<HandleRequestBodyAndCompileRequestDelegate>b__0>d.MoveNext() in Microsoft.AspNetCore.Http.Extensions.dll:token 0x6000194+0xd4
-//       --- End of stack trace from previous location ---
-//          at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger) in Microsoft.AspNetCore.Routing.dll:token 0x60000ab+0x5e
-//          at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application) in Microsoft.AspNetCore.Server.Kestrel.Core.dll:token 0x6000ac9+0x1b8
-// ```
+// Uncomment to see both routes work:
+// var container = new Container(Rules.MicrosoftDependencyInjectionRules);
+// container.Register<Bar>();
+// builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(container));
 
-//builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory());
 
 builder.Services.AddTransient<Foo>();
 
 var app = builder.Build();
-app.MapGet("/", (Foo foo) => $"Hello world {foo.GetType()}");
+
+app.MapGet("/", (Foo foo) => $"Hello world with `{foo}`");
+app.MapGet("/bar", (Foo foo, Bar bar) => $"Hello world with `{foo}` and `{bar}`");
+
 app.Run();
 
 public class Foo
 {
-
+    public Foo(Bar bar = null) {}
 }
+
+public class Bar {}


### PR DESCRIPTION
Tricky beast is implemented, and it seemingly solves the cryptic error.

In addition, DryIoc.MS.DI now implements the `ISupportRequiredService` but it's probably unrelated.  